### PR TITLE
Add hidden debug logging for nonlinear solver iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,29 @@ The app re-solves the entire flowsheet for each point and plots the result. Poin
 
 ---
 
+
+### Hidden Solver Debug Logging
+
+Solver debug output is **off by default**. You can enable it only from code or environment variables:
+
+```matlab
+solver = proc.ProcessSolver(streams, units);
+solver.debugLevel = 2;   % 0=off, 1=iter summary, 2=+top residuals at exit, 3=+periodic top residuals
+solver.debugTopN = 10;
+solver.debugEvery = 0;   % 0 = only at exit
+solver.solve();
+```
+
+Or set an environment variable before launching MATLAB:
+
+```bash
+export MATHLAB_DEBUG=2
+```
+
+`MATHLAB_DEBUG` raises the active debug level without changing call sites, and can be combined with solver settings.
+
+---
+
 ## Key Concepts
 
 ### Known vs Unknown


### PR DESCRIPTION
### Motivation
- Provide a hidden, opt-in debugging facility for the nonlinear solver to aid diagnosing difficult converges without exposing verbose output to normal users. 
- Allow later extension of debug behaviors via a single configurable toggle (levels/struct/env) without changing solver call sites. 
- Surface per-iteration numeric diagnostics and top residual component lists so users can quickly locate problematic equations or units. 

### Description
- Added hidden solver properties on `ProcessSolver`: `debug`, `debugLevel`, `debugTopN`, `debugEvery`, `debugOut`, and `debugEqNames` with conservative defaults that keep logging off for normal runs. 
- Wired debug option resolution through a new helper `resolveDebugOptions` that merges `ProcessSolver` fields, an optional hidden `solverSettings.debugStruct`, and the environment variable `MATHLAB_DEBUG` (env overrides/raises level). 
- Emitted per-iteration diagnostics via `debugPrintIter` (iteration, `||r||2`, `||r||inf`, `||dx||`, `alpha`, `bt`, and index/value of the max residual) and top-N residuals via `debugPrintTopResiduals` (human-readable labels when available, fallback to `eq ##`). 
- Built lightweight equation labeling in `buildEquationLabels` by querying unit `equationLabels()` when available or falling back to unit `describe()` and per-unit eq indices. 
- Kept public solver behavior unchanged (no API breaking changes), integrated debug prints into the existing solve loop and printed top residuals at solver exit (and optionally every `debugEvery` iterations at higher levels). 
- Updated `README.md` with instructions to enable debugging via `solver.debugLevel = N` or the `MATHLAB_DEBUG` environment variable. 

### Testing
- Performed static checks and code edits succeeded (file updates applied to `+proc/ProcessSolver.m` and `README.md`) and repository shows staged changes were committed. 
- Searched and validated inserted debug markers via `rg`/`nl` to confirm the new methods and option wiring are present. 
- Attempted to run the example script `examples/run_case_water.m` under MATLAB and Octave, but neither MATLAB nor Octave was available in this environment so runtime convergence tests could not be executed. 
- No automated numerical regression tests were modified; the change is additive and only impacts behavior when debug is enabled.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b9d38e3a48333925fac08075addb6)