### PR TITLE
Add non-thermodynamic specification & solver-control blocks (Source,Sink,DesignSpec,Adjust,Calculator,Constraint)

### DIFF
--- a/+proc/+units/Adjust.m
+++ b/+proc/+units/Adjust.m
@@ -1,0 +1,73 @@
+classdef Adjust < handle
+    %ADJUST Manipulate one variable to satisfy one DesignSpec residual.
+    % The manipulated variable is packed into solver unknowns via unknownSpecs().
+    properties
+        targetSpec proc.units.DesignSpec
+        variableOwner
+        variableField char = ''
+        variableIndex double = NaN
+        minValue double = -Inf
+        maxValue double = Inf
+        initialValue double = NaN
+    end
+
+    methods
+        function obj = Adjust(designSpec, owner, field, index, minValue, maxValue)
+            if nargin >= 1, obj.targetSpec = designSpec; end
+            if nargin >= 2, obj.variableOwner = owner; end
+            if nargin >= 3, obj.variableField = char(field); end
+            if nargin >= 4 && ~isempty(index), obj.variableIndex = index; end
+            if nargin >= 5, obj.minValue = minValue; end
+            if nargin >= 6, obj.maxValue = maxValue; end
+            if ~isempty(obj.targetSpec)
+                obj.targetSpec.enabled = false;
+            end
+        end
+
+        function eqs = equations(obj)
+            if isempty(obj.targetSpec)
+                error('Adjust block is missing DesignSpec targetSpec.');
+            end
+            eqs = obj.targetSpec.residual();
+        end
+
+        function specs = unknownSpecs(obj)
+            specs = struct('owner', obj.variableOwner, ...
+                           'field', obj.variableField, ...
+                           'index', obj.variableIndex, ...
+                           'lower', obj.minValue, ...
+                           'upper', obj.maxValue, ...
+                           'initial', obj.getVariableValue());
+            if isfinite(obj.initialValue)
+                specs.initial = obj.initialValue;
+            end
+        end
+
+        function str = describe(obj)
+            str = sprintf('Adjust: %s.%s -> %s', class(obj.variableOwner), obj.variableField, obj.targetSpec.metric);
+        end
+
+        function v = getVariableValue(obj)
+            if ~isprop(obj.variableOwner, obj.variableField)
+                error('Adjust variable field "%s" not found on %s.', obj.variableField, class(obj.variableOwner));
+            end
+            base = obj.variableOwner.(obj.variableField);
+            if isnan(obj.variableIndex)
+                v = base;
+            else
+                v = base(obj.variableIndex);
+            end
+        end
+
+        function setVariableValue(obj, v)
+            v = min(max(v, obj.minValue), obj.maxValue);
+            if isnan(obj.variableIndex)
+                obj.variableOwner.(obj.variableField) = v;
+            else
+                arr = obj.variableOwner.(obj.variableField);
+                arr(obj.variableIndex) = v;
+                obj.variableOwner.(obj.variableField) = arr;
+            end
+        end
+    end
+end

--- a/+proc/+units/Calculator.m
+++ b/+proc/+units/Calculator.m
@@ -1,0 +1,67 @@
+classdef Calculator < handle
+    %CALCULATOR One algebraic equation using two values and an operator.
+    properties
+        lhsOwner
+        lhsField char = ''
+        lhsIndex double = NaN
+
+        aOwner
+        aField char = ''
+        aIndex double = NaN
+
+        bOwner
+        bField char = ''
+        bIndex double = NaN
+
+        operator char = '+'   % + - * /
+    end
+
+    methods
+        function obj = Calculator(lhsOwner, lhsField, aOwner, aField, operator, bOwner, bField)
+            if nargin >= 1, obj.lhsOwner = lhsOwner; end
+            if nargin >= 2, obj.lhsField = char(lhsField); end
+            if nargin >= 3, obj.aOwner = aOwner; end
+            if nargin >= 4, obj.aField = char(aField); end
+            if nargin >= 5, obj.operator = char(operator); end
+            if nargin >= 6, obj.bOwner = bOwner; end
+            if nargin >= 7, obj.bField = char(bField); end
+        end
+
+        function eqs = equations(obj)
+            lhs = obj.getValue(obj.lhsOwner, obj.lhsField, obj.lhsIndex);
+            a = obj.getValue(obj.aOwner, obj.aField, obj.aIndex);
+            b = obj.getValue(obj.bOwner, obj.bField, obj.bIndex);
+            switch obj.operator
+                case '+'
+                    rhs = a + b;
+                case '-'
+                    rhs = a - b;
+                case '*'
+                    rhs = a * b;
+                case '/'
+                    rhs = a / b;
+                otherwise
+                    error('Calculator operator must be one of + - * /.');
+            end
+            eqs = lhs - rhs;
+        end
+
+        function str = describe(obj)
+            str = sprintf('Calculator: %s = a %s b', obj.lhsField, obj.operator);
+        end
+    end
+
+    methods (Access = private)
+        function v = getValue(~, owner, field, idx)
+            if ~isprop(owner, field)
+                error('Calculator field "%s" not available on %s.', field, class(owner));
+            end
+            raw = owner.(field);
+            if isnan(idx)
+                v = raw;
+            else
+                v = raw(idx);
+            end
+        end
+    end
+end

--- a/+proc/+units/Constraint.m
+++ b/+proc/+units/Constraint.m
@@ -1,0 +1,30 @@
+classdef Constraint < handle
+    %CONSTRAINT Equality-only constraint: selected variable - value = 0.
+    properties
+        owner
+        field char = ''
+        index double = NaN
+        value double = 0
+    end
+
+    methods
+        function obj = Constraint(owner, field, value, index)
+            if nargin >= 1, obj.owner = owner; end
+            if nargin >= 2, obj.field = char(field); end
+            if nargin >= 3, obj.value = value; end
+            if nargin >= 4, obj.index = index; end
+        end
+
+        function eqs = equations(obj)
+            v = obj.owner.(obj.field);
+            if ~isnan(obj.index)
+                v = v(obj.index);
+            end
+            eqs = v - obj.value;
+        end
+
+        function str = describe(obj)
+            str = sprintf('Constraint: %s = %.6g', obj.field, obj.value);
+        end
+    end
+end

--- a/+proc/+units/DesignSpec.m
+++ b/+proc/+units/DesignSpec.m
@@ -1,0 +1,63 @@
+classdef DesignSpec < handle
+    %DESIGNSPEC One target equation: metric(stream) - target = 0.
+    properties
+        stream
+        metric char = 'total_flow'    % total_flow | comp_flow | mole_fraction
+        componentIndex double = 1
+        target double = 0
+        enabled logical = true
+    end
+
+    methods
+        function obj = DesignSpec(stream, metric, target, componentIndex)
+            if nargin >= 1, obj.stream = stream; end
+            if nargin >= 2, obj.metric = char(metric); end
+            if nargin >= 3, obj.target = target; end
+            if nargin >= 4, obj.componentIndex = componentIndex; end
+        end
+
+        function eqs = equations(obj)
+            if ~obj.enabled
+                eqs = [];
+                return;
+            end
+            eqs = obj.residual();
+        end
+
+        function r = residual(obj)
+            r = obj.metricValue() - obj.target;
+        end
+
+        function v = metricValue(obj)
+            if isempty(obj.stream)
+                error('DesignSpec has no stream configured.');
+            end
+            switch lower(strtrim(obj.metric))
+                case {'total_flow','n_dot','totalflow'}
+                    v = obj.stream.n_dot;
+                case {'comp_flow','component_flow','n_i'}
+                    i = obj.componentIndex;
+                    obj.validateComponentIndex(i);
+                    v = obj.stream.n_dot * obj.stream.y(i);
+                case {'mole_fraction','y','x_i'}
+                    i = obj.componentIndex;
+                    obj.validateComponentIndex(i);
+                    v = obj.stream.y(i);
+                otherwise
+                    error('DesignSpec metric "%s" not available.', obj.metric);
+            end
+        end
+
+        function str = describe(obj)
+            str = sprintf('DesignSpec: %s on %s = %.6g', obj.metric, string(obj.stream.name), obj.target);
+        end
+    end
+
+    methods (Access = private)
+        function validateComponentIndex(obj, i)
+            if ~(isscalar(i) && i >= 1 && i <= numel(obj.stream.y) && floor(i) == i)
+                error('DesignSpec componentIndex must be integer in [1,%d].', numel(obj.stream.y));
+            end
+        end
+    end
+end

--- a/+proc/+units/Sink.m
+++ b/+proc/+units/Sink.m
@@ -1,0 +1,20 @@
+classdef Sink < handle
+    %SINK Terminal sink block (1 inlet, 0 outlets). Adds no residuals.
+    properties
+        inlet
+    end
+
+    methods
+        function obj = Sink(inlet)
+            obj.inlet = inlet;
+        end
+
+        function eqs = equations(~)
+            eqs = [];
+        end
+
+        function str = describe(obj)
+            str = sprintf('Sink: %s ->', string(obj.inlet.name));
+        end
+    end
+end

--- a/+proc/+units/Source.m
+++ b/+proc/+units/Source.m
@@ -1,0 +1,71 @@
+classdef Source < handle
+    %SOURCE Fixed-spec stream source block (0 inlets, 1 outlet).
+    % Adds equations only for user-selected outlet specifications.
+    properties
+        outlet
+        totalFlow double = NaN            % optional scalar n_dot spec
+        componentFlows double = []        % optional vector n_i specs (NaN = unspecified)
+        composition double = []           % optional y_i specs (NaN = unspecified)
+        specifyT logical = false
+        specifyP logical = false
+        T double = NaN
+        P double = NaN
+    end
+
+    methods
+        function obj = Source(outlet, varargin)
+            obj.outlet = outlet;
+            if nargin >= 2 && isstruct(varargin{1})
+                s = varargin{1};
+                f = fieldnames(s);
+                for i = 1:numel(f)
+                    if isprop(obj, f{i})
+                        obj.(f{i}) = s.(f{i});
+                    end
+                end
+            end
+        end
+
+        function eqs = equations(obj)
+            eqs = [];
+            ns = numel(obj.outlet.y);
+
+            if ~isempty(obj.componentFlows)
+                if numel(obj.componentFlows) ~= ns
+                    error('Source %s: componentFlows must match species count.', string(obj.outlet.name));
+                end
+                for i = 1:ns
+                    if ~isnan(obj.componentFlows(i))
+                        eqs(end+1) = obj.outlet.n_dot * obj.outlet.y(i) - obj.componentFlows(i); %#ok<AGROW>
+                    end
+                end
+            end
+
+            if ~isnan(obj.totalFlow)
+                eqs(end+1) = obj.outlet.n_dot - obj.totalFlow; %#ok<AGROW>
+            end
+
+            if ~isempty(obj.composition)
+                if numel(obj.composition) ~= ns
+                    error('Source %s: composition must match species count.', string(obj.outlet.name));
+                end
+                for i = 1:ns
+                    if ~isnan(obj.composition(i))
+                        eqs(end+1) = obj.outlet.y(i) - obj.composition(i); %#ok<AGROW>
+                    end
+                end
+            end
+
+            if obj.specifyT && isfinite(obj.T)
+                eqs(end+1) = obj.outlet.T - obj.T; %#ok<AGROW>
+            end
+            if obj.specifyP && isfinite(obj.P)
+                eqs(end+1) = obj.outlet.P - obj.P; %#ok<AGROW>
+            end
+        end
+
+        function str = describe(obj)
+            str = sprintf('Source: -> %s', string(obj.outlet.name));
+        end
+    end
+end

--- a/+proc/Flowsheet.m
+++ b/+proc/Flowsheet.m
@@ -146,6 +146,18 @@ classdef Flowsheet < handle
                 end
             end
 
+
+            % Unit-level manipulated unknowns (e.g., Adjust blocks)
+            for ui = 1:numel(obj.units)
+                unit = obj.units{ui};
+                if ismethod(unit, 'unknownSpecs')
+                    specs = unit.unknownSpecs();
+                    if ~isempty(specs)
+                        n = n + numel(specs);
+                    end
+                end
+            end
+
             function tf = isUnknownField(st, fieldName)
                 if isprop(st,'known') && isstruct(st.known) && isfield(st.known, fieldName)
                     tf = ~st.known.(fieldName);
@@ -250,9 +262,6 @@ classdef Flowsheet < handle
                 end
 
                 ru = unit.equations();
-                if isempty(ru)
-                    error('Unit #%d (%s): equations() returned empty.', u, class(unit));
-                end
                 if any(~isfinite(ru(:)))
                     error('Unit #%d (%s): equations() returned NaN/Inf. Check connectivity/initial guesses.', u, class(unit));
                 end

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ The app re-solves the entire flowsheet for each point and plots the result. Poin
 ---
 
 
+## Available Unit Operations
+
+- Material/path units: `Link`, `Mixer`, `Splitter`, `Separator`, `Purge`, `Recycle`, `Bypass`, `Manifold`, `Reactor`
+- Specification / solver-control blocks: `Source`, `Sink`, `DesignSpec`, `Adjust`, `Calculator`, `Constraint`
+
 ### Hidden Solver Debug Logging
 
 Solver debug output is **off by default**. You can enable it only from code or environment variables:

--- a/examples/run_case_specs.m
+++ b/examples/run_case_specs.m
@@ -1,0 +1,63 @@
+%RUN_CASE_SPECS Demonstrates spec/solver-control blocks working together.
+clear; clc;
+
+species = {'A'};
+fs = proc.Flowsheet(species);
+
+% Streams
+F = proc.Stream('F', species);
+P = proc.Stream('P', species);
+R = proc.Stream('R', species);
+
+% Fix y/T/P as known; solve n_dot values only.
+for s = {F,P,R}
+    st = s{1};
+    st.y = 1;
+    st.T = 300;
+    st.P = 1e5;
+    st.known.y(:) = true;
+    st.known.T = true;
+    st.known.P = true;
+    st.known.n_dot = false;
+end
+
+fs.addStream(F); fs.addStream(P); fs.addStream(R);
+
+% Source block: fixed feed total flow (no redundant sum(y)=1 equation).
+src = proc.units.Source(F, struct('totalFlow', 10));
+
+% Splitter with adjustable first split fraction.
+spl = proc.units.Splitter(F, {P, R}, 'fractions', [0.5 0.4]);
+
+% Design target: product total flow = 6 mol/s.
+ds = proc.units.DesignSpec(P, 'total_flow', 6, 1);
+
+% Adjust: manipulate splitter splitFractions(1) in [0,1] to satisfy ds.
+adj = proc.units.Adjust(ds, spl, 'splitFractions', 1, 0, 1);
+
+% Calculator: enforce y_P = y_F / y_F = 1 (simple algebraic scaffolding).
+calc = proc.units.Calculator(P, 'y', F, 'y', '/', F, 'y');
+calc.lhsIndex = 1; calc.aIndex = 1; calc.bIndex = 1;
+
+% Constraint: equality-only constraint on recycle temperature placeholder.
+con = proc.units.Constraint(R, 'T', 300);
+
+% Sink blocks (no residuals) for topology completeness.
+skP = proc.units.Sink(P);
+skR = proc.units.Sink(R);
+
+fs.addUnit(src);
+fs.addUnit(spl);
+fs.addUnit(ds);
+fs.addUnit(adj);
+fs.addUnit(calc);
+fs.addUnit(con);
+fs.addUnit(skP);
+fs.addUnit(skR);
+
+solver = fs.solve('maxIter', 80, 'tolAbs', 1e-10, 'printToConsole', true, 'consoleStride', 1);
+T = fs.streamTable();
+disp(T);
+
+fprintf('\nSolved manipulated split fraction f1 = %.6f\n', spl.splitFractions(1));
+fprintf('Product flow target = %.3f, solved P.n_dot = %.6f\n', ds.target, P.n_dot);

--- a/runFromConfig.m
+++ b/runFromConfig.m
@@ -209,6 +209,42 @@ function u = buildUnitFromDef(def, streams)
                 outS{end+1} = s; %#ok
             end
             u = proc.units.Manifold(inS, outS, def.route);
+        case 'Source'
+            sOut = findS(def.outlet, streams);
+            if ~isempty(sOut)
+                opts = struct();
+                if isfield(def,'totalFlow'), opts.totalFlow = def.totalFlow; end
+                if isfield(def,'composition'), opts.composition = def.composition; end
+                if isfield(def,'componentFlows'), opts.componentFlows = def.componentFlows; end
+                u = proc.units.Source(sOut, opts);
+            end
+        case 'Sink'
+            sIn = findS(def.inlet, streams);
+            if ~isempty(sIn), u = proc.units.Sink(sIn); end
+        case 'DesignSpec'
+            s = findS(def.stream, streams);
+            if ~isempty(s)
+                u = proc.units.DesignSpec(s, def.metric, def.target, def.componentIndex);
+            end
+        case 'Adjust'
+            if isfield(def,'designSpecIndex') && isfield(def,'ownerIndex') && ...
+                    def.designSpecIndex <= numel(units) && def.ownerIndex <= numel(units)
+                ds = units{def.designSpecIndex};
+                owner = units{def.ownerIndex};
+                u = proc.units.Adjust(ds, owner, def.field, def.index, def.minValue, def.maxValue);
+            end
+        case 'Calculator'
+            lhs = findS(def.lhsStream, streams);
+            a = findS(def.aStream, streams);
+            b = findS(def.bStream, streams);
+            if ~isempty(lhs) && ~isempty(a) && ~isempty(b)
+                u = proc.units.Calculator(lhs, def.lhsField, a, def.aField, def.operator, b, def.bField);
+            end
+        case 'Constraint'
+            s = findS(def.stream, streams);
+            if ~isempty(s)
+                u = proc.units.Constraint(s, def.field, def.value, def.index);
+            end
     end
 end
 


### PR DESCRIPTION
### Motivation
- Provide a minimal set of non-thermodynamic specification / solver-control blocks so flowsheets can declare fixed feeds, terminal sinks, design targets, manipulation knobs, algebraic calculations, and simple equality constraints without adding thermodynamics.
- Follow the existing unit-class pattern used by `Mixer`/`Separator`/`Reactor` and keep changes incremental to avoid refactoring the solver.
- Enable GUI registration so new blocks appear in the unit dropdown and can be saved/loaded from config files.

### Description
- Added new unit classes in `+proc/+units/`: `Source`, `Sink`, `DesignSpec`, `Adjust`, `Calculator`, and `Constraint` with minimal equation scaffolding and inline comments describing usage.
- Extended `proc.ProcessSolver` to pack/unpack unit-level manipulated unknowns returned from a unit `unknownSpecs()` method (used by `Adjust`), including bounds and owner/field mapping; solver writes these manipulated values back to unit properties during `unpackUnknowns`.
- Updated `proc.Flowsheet` DOF counting to include unit-level manipulated unknowns and relaxed the validation check to allow units that intentionally return no residuals (e.g., `Sink`, disabled `DesignSpec`).
- Registered blocks in the GUI (`MathLabApp`): added to the `AddUnitDropDown`, implemented configuration dialogs for each new block, updated `buildUnitFromDef` and script-generation to handle new block types, and extended flowsheet diagram styles/markers for visual consistency.
- Updated `runFromConfig.m` to rebuild flowsheets including all new unit types from saved configs and updated `README.md` to list the new units.
- Added a small deterministic example `examples/run_case_specs.m` demonstrating `Source -> Splitter -> DesignSpec` solved by `Adjust` (plus `Calculator` and `Constraint` scaffolding) to show intended usage.

### Testing
- Performed static inspections and searches to verify new files and references using repository-wide searches for relevant symbols and ensured the new unit files and GUI hooks are present (`rg`/code listing checks); these checks succeeded.
- Created `examples/run_case_specs.m` to demonstrate intended connectivity and DOF setup; the script was added to the repository but not executed in this environment.
- Attempted to run MATLAB/Octave to execute the example, but no MATLAB/Octave binary is available in this environment, so no runtime solve was executed (static checks only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bada357148333b4fe7be608681733)