### PR TITLE
Adopt independent component-balance equation policy across unit models

### DIFF
--- a/+proc/+units/Bypass.m
+++ b/+proc/+units/Bypass.m
@@ -23,16 +23,15 @@ classdef Bypass < handle
             ns = numel(obj.inlet.y);
             b = obj.bypassFraction;
 
-            % Internal splitter section
-            eqs(end+1) = obj.processInlet.n_dot - (1 - b) * obj.inlet.n_dot;
-            eqs(end+1) = obj.bypassStream.n_dot - b * obj.inlet.n_dot;
+            % Internal splitter section (component balances)
             for i = 1:ns
-                eqs(end+1) = obj.processInlet.y(i) - obj.inlet.y(i);
-                eqs(end+1) = obj.bypassStream.y(i) - obj.inlet.y(i);
+                eqs(end+1) = obj.processInlet.n_dot * obj.processInlet.y(i) ...
+                          - (1 - b) * obj.inlet.n_dot * obj.inlet.y(i);
+                eqs(end+1) = obj.bypassStream.n_dot * obj.bypassStream.y(i) ...
+                          - b * obj.inlet.n_dot * obj.inlet.y(i);
             end
 
-            % Internal mixer section
-            eqs(end+1) = obj.outlet.n_dot - (obj.bypassStream.n_dot + obj.processReturn.n_dot);
+            % Internal mixer section (component balances)
             for i = 1:ns
                 eqs(end+1) = obj.outlet.n_dot * obj.outlet.y(i) ...
                           - (obj.bypassStream.n_dot * obj.bypassStream.y(i) ...

--- a/+proc/+units/ConversionReactor.m
+++ b/+proc/+units/ConversionReactor.m
@@ -57,8 +57,7 @@ classdef ConversionReactor < handle
                 obj.didWarnNegative = true;
             end
 
-            eqs = [nOutVar - nTarget; obj.outlet.n_dot - sum(nTarget); ...
-                obj.outlet.T - obj.inlet.T; obj.outlet.P - obj.inlet.P];
+            eqs = [nOutVar - nTarget; obj.outlet.T - obj.inlet.T; obj.outlet.P - obj.inlet.P];
         end
 
         function str = describe(obj)

--- a/+proc/+units/Link.m
+++ b/+proc/+units/Link.m
@@ -12,12 +12,12 @@ classdef Link < handle
 
         function eqs = equations(obj)
             eqs = [];
-            eqs(end+1) = obj.outlet.n_dot - obj.inlet.n_dot;
+            for i = 1:numel(obj.inlet.y)
+                eqs(end+1) = obj.outlet.n_dot * obj.outlet.y(i) ...
+                          - obj.inlet.n_dot * obj.inlet.y(i);
+            end
             eqs(end+1) = obj.outlet.T - obj.inlet.T;
             eqs(end+1) = obj.outlet.P - obj.inlet.P;
-            for i = 1:numel(obj.inlet.y)
-                eqs(end+1) = obj.outlet.y(i) - obj.inlet.y(i);
-            end
         end
 
         function str = describe(obj)

--- a/+proc/+units/Manifold.m
+++ b/+proc/+units/Manifold.m
@@ -20,9 +20,8 @@ classdef Manifold < handle
             for k = 1:nOut
                 src = obj.inlets{obj.route(k)};
                 out = obj.outlets{k};
-                eqs(end+1) = out.n_dot - src.n_dot;
                 for i = 1:ns
-                    eqs(end+1) = out.y(i) - src.y(i);
+                    eqs(end+1) = out.n_dot * out.y(i) - src.n_dot * src.y(i);
                 end
             end
         end

--- a/+proc/+units/Mixer.m
+++ b/+proc/+units/Mixer.m
@@ -13,14 +13,7 @@ classdef Mixer < handle
         function eqs = equations(obj)
             eqs = [];
 
-            % Total molar flow
-            total_n_in = 0;
-            for i = 1:length(obj.inlets)
-                total_n_in = total_n_in + obj.inlets{i}.n_dot;
-            end
-            eqs(end+1) = obj.outlet.n_dot - total_n_in;
-
-            % Species balances
+            % Species balances as primary conserved equations
             nspecies = length(obj.outlet.y);
             for j = 1:nspecies
                 total_species_in = 0;

--- a/+proc/+units/Purge.m
+++ b/+proc/+units/Purge.m
@@ -5,7 +5,7 @@ classdef Purge < handle
         purge       % Stream (leaves the process)
         beta        % recycle fraction (0..1)
         mode = "fixed"
-        includeNormalizationConstraints logical = true
+        includeNormalizationConstraints logical = false
         
     end
 
@@ -30,7 +30,7 @@ classdef Purge < handle
                           - (1 - b) * obj.inlet.n_dot * obj.inlet.y(i);
             end
 
-            % Mole fraction normalization (optional; can be redundant if y is parameterized)
+            % Mole fraction normalization (legacy optional; disabled by default because y uses softmax parameterization)
             if obj.includeNormalizationConstraints
                 eqs(end+1) = sum(obj.recycle.y) - 1;
                 eqs(end+1) = sum(obj.purge.y) - 1;

--- a/+proc/+units/Reactor.m
+++ b/+proc/+units/Reactor.m
@@ -50,8 +50,7 @@ classdef Reactor < handle
             n_out = sum(n_species);
             y_out = n_species / n_out;
 
-            % Step 4: Build residuals
-            eqs(end+1) = obj.outlet.n_dot - n_out;
+            % Step 4: Build residuals from component balances
             for j = 1:nspecies
                 eqs(end+1) = obj.outlet.n_dot * obj.outlet.y(j) - n_out * y_out(j);
             end

--- a/+proc/+units/Recycle.m
+++ b/+proc/+units/Recycle.m
@@ -12,9 +12,9 @@ classdef Recycle < handle
 
         function eqs = equations(obj)
             eqs = [];
-            eqs(end+1) = obj.tear.n_dot - obj.source.n_dot;
             for i = 1:numel(obj.source.y)
-                eqs(end+1) = obj.tear.y(i) - obj.source.y(i);
+                eqs(end+1) = obj.tear.n_dot * obj.tear.y(i) ...
+                          - obj.source.n_dot * obj.source.y(i);
             end
         end
 

--- a/+proc/+units/Separator.m
+++ b/+proc/+units/Separator.m
@@ -4,7 +4,7 @@ classdef Separator < handle
         outletA    % Stream object (e.g. gas / recycle)
         outletB    % Stream object (e.g. liquid / product)
         phi        % split fraction to outletA for each species (0..1), size = nspecies
-        includeNormalizationConstraints logical = true
+        includeNormalizationConstraints logical = false
     end
 
     methods
@@ -27,7 +27,7 @@ classdef Separator < handle
                           - (1 - obj.phi(i)) * obj.inlet.n_dot * obj.inlet.y(i);
             end
 
-            % Mole fraction sum constraints (optional; can be redundant if y is parameterized)
+            % Mole fraction sum constraints (legacy optional; disabled by default because y uses softmax parameterization)
             if obj.includeNormalizationConstraints
                 eqs(end+1) = sum(obj.outletA.y) - 1;
                 eqs(end+1) = sum(obj.outletB.y) - 1;

--- a/+proc/+units/Splitter.m
+++ b/+proc/+units/Splitter.m
@@ -40,9 +40,8 @@ classdef Splitter < handle
                 f = obj.splitFractions;
                 for k = 1:nOut
                     out = obj.outlets{k};
-                    eqs(end+1) = out.n_dot - f(k) * obj.inlet.n_dot;
                     for i = 1:ns
-                        eqs(end+1) = out.y(i) - obj.inlet.y(i);
+                        eqs(end+1) = out.n_dot * out.y(i) - f(k) * obj.inlet.n_dot * obj.inlet.y(i);
                     end
                 end
             else

--- a/+proc/+units/StoichiometricReactor.m
+++ b/+proc/+units/StoichiometricReactor.m
@@ -55,8 +55,7 @@ classdef StoichiometricReactor < handle
                 obj.didWarnNegative = true;
             end
 
-            eqs = [nOutVar - nTarget; obj.outlet.n_dot - sum(nTarget); ...
-                obj.outlet.T - obj.inlet.T; obj.outlet.P - obj.inlet.P];
+            eqs = [nOutVar - nTarget; obj.outlet.T - obj.inlet.T; obj.outlet.P - obj.inlet.P];
         end
 
         function str = describe(obj)

--- a/+proc/+units/YieldReactor.m
+++ b/+proc/+units/YieldReactor.m
@@ -68,8 +68,7 @@ classdef YieldReactor < handle
                 obj.didWarnNegative = true;
             end
 
-            eqs = [nOutVar - nTarget; obj.outlet.n_dot - sum(nTarget); ...
-                obj.outlet.T - obj.inlet.T; obj.outlet.P - obj.inlet.P];
+            eqs = [nOutVar - nTarget; obj.outlet.T - obj.inlet.T; obj.outlet.P - obj.inlet.P];
         end
 
         function str = describe(obj)

--- a/README.md
+++ b/README.md
@@ -181,6 +181,29 @@ For the GUI to support your custom unit, add a dialog method in MathLabApp.m and
 
 ---
 
+
+## Equation Independence Policy (`+proc/+units/*.m`)
+
+MathLab unit equations now follow a repository-wide independence policy:
+
+- Prefer **component molar flow balances** (`n_dot * y_i`) as the primary conserved equations for material units.
+- Avoid enforcing all three at once for the same material relation: component balances, total-flow balance, and composition normalization.
+- Composition normalization belongs to variable parameterization (the solver softmax map), not usually to unit residuals.
+- Keep `T`/`P` equations only when they represent intentional unit physics; avoid adding duplicate pass-through constraints that are just wiring artifacts.
+
+### Examples
+
+- **Independent set (preferred)** for a mixer with `ns` species:
+  - `ns` component balances on outlet `n_dot * y_i`
+  - optional thermal/mechanical model equations (`T`, `P`) if physically intended
+
+- **Redundant set (avoid)** for the same mixer:
+  - `ns` component balances
+  - plus total-flow balance
+  - plus explicit `sum(y)=1` normalization residual
+
+Because stream compositions are packed with a softmax transform in `ProcessSolver`, `sum(y)=1` is already guaranteed by construction.
+
 ## Troubleshooting
 
 | Problem | Likely Cause / Fix |


### PR DESCRIPTION
### Motivation

- Improve solver conditioning and DOF clarity by enforcing independent, non-redundant material equations across unit models. 
- Prefer component molar flow balances as the primary conserved equations so mass conservation is expressed in an intrinsic, per-species way. 
- Align unit equation sets with the solver's composition parameterization (softmax) and avoid duplicate normalization or pass-through wiring residuals.

### Description

- Replace total-flow + composition wiring in topology/pass-through units with component molar flow residuals (`n_dot * y_i`) in `Link`, `Recycle`, `Manifold`, `Splitter` (fractions mode), `Mixer`, and `Bypass`. 
- Convert reactor-style blocks to use component balances as the primary residuals and remove redundant `outlet.n_dot - sum(...)` total-flow residuals from `Reactor`, `StoichiometricReactor`, `ConversionReactor`, and `YieldReactor`. 
- Make unit-level composition normalization constraints legacy/optional and disabled by default by setting `includeNormalizationConstraints = false` in `Separator` and `Purge`, and update their help text to indicate why. 
- Add a developer-facing section to `README.md` titled “Equation Independence Policy” that documents the rationale, preferred independent equation sets (examples), and guidance about keeping `T`/`P` equations only when they represent intended unit physics.

### Testing

- Ran static checks including `git diff --check` to verify no whitespace/conflict markers and these checks passed. 
- Verified code patterns and replacements via repository searches to ensure `n_dot * y` component residuals were added and redundant total-flow/normalization residuals were removed. 
- Did not run the MATLAB/Octave non-GUI regression suite in this environment because MATLAB/Octave is not available here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb0e9e32c83339f71b32e228c70e0)