### PR TITLE
Refine Mixer equation formulation to avoid dependent constraints

### DIFF
--- a/+proc/+units/Mixer.m
+++ b/+proc/+units/Mixer.m
@@ -13,7 +13,15 @@ classdef Mixer < handle
         function eqs = equations(obj)
             eqs = [];
 
-            % Species balances as primary conserved equations
+            % Independence rationale:
+            % - Use component-flow balances (n_dot*y) as the primary conservation equations.
+            % - Do NOT add a separate total-flow equation here because it is implied by
+            %   summing the component balances when stream compositions are normalized.
+            % - Keep only physically intended closure relations (T/P matching assumption).
+            %
+            % This keeps the mixer equation set free of avoidable dependent constraints.
+
+            % Component molar balances as primary conserved equations
             nspecies = length(obj.outlet.y);
             for j = 1:nspecies
                 total_species_in = 0;
@@ -23,7 +31,7 @@ classdef Mixer < handle
                 eqs(end+1) = obj.outlet.n_dot * obj.outlet.y(j) - total_species_in;
             end
 
-            % T/P: match first inlet (adiabatic assumption)
+            % Mechanical/thermal closure: match first inlet (adiabatic/isobaric assumption)
             eqs(end+1) = obj.outlet.T - obj.inlets{1}.T;
             eqs(end+1) = obj.outlet.P - obj.inlets{1}.P;
         end


### PR DESCRIPTION
### Motivation
- Avoid introducing dependent equations in the mixer by using component molar balances (component-flow form) as the primary conserved equations and only keeping intended thermal/mechanical closure relations.

### Description
- Added an "Independence rationale" comment block to `+proc/+units/Mixer.m` that documents using component-flow balances and explicitly advises against adding an explicit total-flow equation because it is implied by summed component balances.
- Kept species balances in component-flow form (`n_dot*y`) for all components and retained the thermal/mechanical closure equations (`T_out = T_in1`, `P_out = P_in1`) so the mixer equation set remains independent.

### Testing
- Applied the patch to `+proc/+units/Mixer.m` and inspected the modified file to confirm the new comments and that the component-flow equations and closure equations remain present, and these checks succeeded.
- Skipped MATLAB/Octave runtime tests per the task instruction and no additional automated model runtime tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb5253d7483338a8213c6ce4f682b)