### PR TITLE
Gauge-fix composition logits and count composition DOFs as ns-1

### DIFF
--- a/+proc/Flowsheet.m
+++ b/+proc/Flowsheet.m
@@ -148,15 +148,18 @@ classdef Flowsheet < handle
 
                 % y
                 if hasKnownY(s)
-                    % count unknown components
-                    for j = 1:ns
-                        if ~s.known.y(j)
-                            n = n + 1;
-                        end
+                    nUnknownY = sum(~s.known.y(:));
+                    if nUnknownY > 0
+                        % Gauge fixing for softmax logits: when composition
+                        % has free dimensions, one unknown component can be
+                        % anchored so composition contributes (nUnknownY-1)
+                        % independent unknowns.
+                        n = n + max(nUnknownY - 1, 0);
                     end
                 else
-                    % if no known flags exist, treat full y as unknown (matches softmax approach)
-                    n = n + ns;
+                    % If known.y flags are unavailable/invalid, composition is
+                    % fully free and contributes (ns-1) independent unknowns.
+                    n = n + max(ns - 1, 0);
                 end
             end
 


### PR DESCRIPTION
### Motivation
- Remove redundant degrees of freedom in stream compositions by treating composition as a softmax over logits with one anchored (gauge-fixed) component per stream so the independent DOFs are `ns-1` instead of `ns`.
- Ensure partial `known.y` masks remain consistent so only truly unknown composition dimensions are treated as solver unknowns.
- Keep solver/unit-level normalization logic consistent with the softmax parameterization to avoid reintroducing normalization constraints that are now redundant.

### Description
- `ProcessSolver.packUnknowns()` now uses `initialCompositionLogits()` to compute and pack only the independent logits for unknown composition components, packing only `(nUnknownY-1)` logits per stream and recording their `subIndex` mapping.
- `ProcessSolver.unpackUnknowns()` now reconstructs full stream compositions via the new `reconstructComposition()` helper which merges known components with a gauge-fixed softmax over the packed logits (anchor = 0 for the last unknown component).
- Added helper methods `compositionKnownMask()`, `unknownCompositionIndices()`, `initialCompositionLogits()`, and `reconstructComposition()` to centralize known/unknown handling and initial-logit preparation, with comments explaining the gauge fixing and its rationale.
- `Flowsheet.countUnknowns()` was updated to count composition DOFs as `nUnknownY-1` when `known.y` is present or `ns-1` when a `known.y` mask is unavailable/invalid, and comments were added to document the change.

### Testing
- The patch was applied successfully and committed (`apply_patch` and `git commit` completed without error). 
- Basic repository checks (`git show --stat`, `git status`) completed and showed the two files updated and committed. 
- MATLAB/Octave tests were not run per environment constraints and project guidance (no Matlab/Octave runtime available).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb7ecd26c8333887a7402842ce4b8)