### PR TITLE
Clarify Heater/Cooler residuals and add multi‑species composition regression

### DIFF
--- a/+proc/+units/Heater.m
+++ b/+proc/+units/Heater.m
@@ -36,25 +36,33 @@ classdef Heater < handle
         function eqs = equations(obj)
             eqs = [];
             ns = numel(obj.inlet.y);
+            y_in = obj.inlet.y(:);
+            y_out = obj.outlet.y(:);
 
-            % Component balances
+            % Residual indices:
+            %   1:ns   -> component balances
+            %   ns+1   -> pressure
+            %   ns+2   -> energy/temperature specification
+            %
+            % Component balances (all species):
+            %   n_out*y_out(i) - n_in*y_in(i) = 0
             for i = 1:ns
-                eqs(end+1) = obj.outlet.n_dot * obj.outlet.y(i) ...
-                           - obj.inlet.n_dot * obj.inlet.y(i);
+                eqs(end+1) = obj.outlet.n_dot * y_out(i) ...
+                           - obj.inlet.n_dot * y_in(i);
             end
 
             % Pressure pass-through (ΔP = 0)
             eqs(end+1) = obj.outlet.P - obj.inlet.P;
 
-            z = obj.inlet.y(:)';
+            z_in = y_in.';
 
             if isfinite(obj.Tout)
                 % Temperature spec: outlet T must equal Tout
                 eqs(end+1) = obj.outlet.T - obj.Tout;
             elseif isfinite(obj.duty)
                 % Duty spec: Q = n_dot * (h_out - h_in)
-                h_in  = obj.thermoMix.h_mix_sensible(obj.inlet.T, z);
-                h_out = obj.thermoMix.h_mix_sensible(obj.outlet.T, z);
+                h_in  = obj.thermoMix.h_mix_sensible(obj.inlet.T, z_in);
+                h_out = obj.thermoMix.h_mix_sensible(obj.outlet.T, z_in);
                 eqs(end+1) = obj.duty - obj.inlet.n_dot * (h_out - h_in);
             else
                 error('Heater: must specify Tout or duty.');
@@ -65,13 +73,21 @@ classdef Heater < handle
             ns = numel(obj.inlet.y);
             labels = strings(ns + 2, 1);
             for i = 1:ns
-                labels(i) = sprintf('Heater %s->%s: component %d mole flow', ...
-                    string(obj.inlet.name), string(obj.outlet.name), i);
+                labels(i) = sprintf('Heater %s->%s residual(%d): n_out*y_out(%d) - n_in*y_in(%d)', ...
+                    string(obj.inlet.name), string(obj.outlet.name), i, i, i);
             end
-            labels(ns+1) = sprintf('Heater %s->%s: pressure', ...
-                string(obj.inlet.name), string(obj.outlet.name));
-            labels(ns+2) = sprintf('Heater %s->%s: energy', ...
-                string(obj.inlet.name), string(obj.outlet.name));
+            labels(ns+1) = sprintf('Heater %s->%s residual(%d): P_out - P_in', ...
+                string(obj.inlet.name), string(obj.outlet.name), ns+1);
+            if isfinite(obj.Tout)
+                labels(ns+2) = sprintf('Heater %s->%s residual(%d): T_out - T_spec', ...
+                    string(obj.inlet.name), string(obj.outlet.name), ns+2);
+            elseif isfinite(obj.duty)
+                labels(ns+2) = sprintf('Heater %s->%s residual(%d): duty - n_in*(h_out-h_in)', ...
+                    string(obj.inlet.name), string(obj.outlet.name), ns+2);
+            else
+                labels(ns+2) = sprintf('Heater %s->%s residual(%d): energy/temperature spec (unset)', ...
+                    string(obj.inlet.name), string(obj.outlet.name), ns+2);
+            end
         end
 
         function Q = getDuty(obj)


### PR DESCRIPTION
### Motivation

- The heater/cooler component balances used inline indexing and transient variables which risked aliasing or vector-orientation bugs that can collapse species composition to the first index or mix composition into the energy/pressure equations.
- Improve diagnostic clarity by documenting residual indexes and giving explicit, self-describing labels for each equation so solver residual traces are easy to interpret.

### Description

- Updated `+proc/+units/Heater.m` to build per-species composition vectors `y_in`/`y_out`, enforce component balances as `n_out*y_out(i) - n_in*y_in(i)`, document residual indexing (`1:ns` components, `ns+1` pressure, `ns+2` energy/temperature), and use a dedicated `z_in` for sensible-enthalpy calls to avoid composition aliasing.
- Applied the same changes to `+proc/+units/Cooler.m` (explicit `y_in`/`y_out`, component residual form, `z_in` usage, and residual index comments).
- Improved `equationLabels()` in both units to include residual indices and equation text for component, pressure, and the selected energy/temperature specification for easier diagnostics.
- Added a new regression test `testHeaterCoolerCompositionPassThrough` in `run_regression_suite.m` that runs a 3-species (`N2`,`O2`,`Ar`) heater and cooler scenario and asserts that each species composition and total molar flow are preserved while temperature/duty specs are enforced.

### Testing

- Performed repository sanity checks including `git diff --check` and committed the changes successfully with a descriptive message.
- Added the new regression test to the `run_regression_suite` list but did not execute MATLAB/Octave tests in this environment per instructions, so no MATLAB regression runs were performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f11b338048333bbff514f97abfe6e)