### PR TITLE
Add read-only Unit Table popup with serializer and CSV/MAT export hooks

### DIFF
--- a/MathLabApp.m
+++ b/MathLabApp.m
@@ -80,6 +80,12 @@ classdef MathLabApp < handle
         % -- Project & Output --
         ProjectTitleField
         SaveResultsBtn
+        OpenUnitTableBtn
+
+        % -- Unit Table popup --
+        UnitTableFig
+        UnitTable
+        UnitTableStatusLabel
     end
 
     % =====================================================================
@@ -178,13 +184,17 @@ classdef MathLabApp < handle
                 'BackgroundColor',[0.95 0.92 0.85], ...
                 'ButtonPushedFcn',@(~,~) app.loadConfigDialog());
 
-            % Save results row
-            resRow = uigridlayout(leftG, [1 1], 'ColumnWidth',{'1x'}, ...
+            % Save results + unit table row
+            resRow = uigridlayout(leftG, [1 2], 'ColumnWidth',{'1x','1x'}, ...
                 'Padding',[0 0 0 0]);
             app.SaveResultsBtn = uibutton(resRow,'push','Text','Save Results', ...
                 'FontWeight','bold', ...
                 'BackgroundColor',[0.85 0.92 0.95], ...
                 'ButtonPushedFcn',@(~,~) app.saveResultsToOutput());
+            app.OpenUnitTableBtn = uibutton(resRow,'push','Text','Open Unit Table', ...
+                'FontWeight','bold', ...
+                'BackgroundColor',[0.90 0.88 0.98], ...
+                'ButtonPushedFcn',@(~,~) app.openUnitTablePopup());
 
             % Placeholder for future options
             uilabel(leftG, 'Text', '');
@@ -593,6 +603,7 @@ classdef MathLabApp < handle
             app.refreshUnitsListBox();
             app.refreshFlowsheetDiagram();
             app.updateDOF();
+            app.refreshUnitTablePopup();
             app.updateSensDropdowns();
             app.refreshSpeciesPropsTable();
             app.StreamNameField.Value = 'S2';
@@ -912,6 +923,7 @@ classdef MathLabApp < handle
             app.refreshUnitsListBox();
             app.refreshFlowsheetDiagram();
             app.updateDOF();
+            app.refreshUnitTablePopup();
         end
 
         function idx = getSelectedUnitIdx(app)
@@ -936,6 +948,7 @@ classdef MathLabApp < handle
             app.refreshUnitsListBox();
             app.refreshFlowsheetDiagram();
             app.updateDOF();
+            app.refreshUnitTablePopup();
         end
     end
 
@@ -1682,6 +1695,235 @@ classdef MathLabApp < handle
         end
     end
 
+
+    % =====================================================================
+    %  UNIT TABLE POPUP
+    % =====================================================================
+    methods (Access = private)
+        function openUnitTablePopup(app)
+            if ~isempty(app.UnitTableFig) && isvalid(app.UnitTableFig)
+                app.refreshUnitTablePopup();
+                app.UnitTableFig.Visible = 'on';
+                return;
+            end
+
+            app.UnitTableFig = uifigure('Name','MathLab — Unit Table', ...
+                'Position',[120 80 980 480], 'Color',[0.97 0.97 0.98]);
+            app.UnitTableFig.CloseRequestFcn = @(src,~) app.onUnitTablePopupClosed(src);
+
+            gl = uigridlayout(app.UnitTableFig, [3 1], ...
+                'RowHeight',{34,'1x',32}, 'Padding',[10 10 10 10], 'RowSpacing',6);
+
+            topG = uigridlayout(gl, [1 4], 'ColumnWidth',{'fit','1x',110,110}, ...
+                'Padding',[0 0 0 0], 'ColumnSpacing',6);
+            topG.Layout.Row = 1;
+            uilabel(topG, 'Text','Unit Table (Read-only)', 'FontWeight','bold', 'FontSize',13);
+            uilabel(topG, 'Text','Type + connected streams + key specs are flattened for quick review.', ...
+                'FontColor',[0.35 0.35 0.35]);
+            uibutton(topG, 'push', 'Text','Export CSV', ...
+                'ButtonPushedFcn',@(~,~) app.exportUnitTableToOutput('csv'));
+            uibutton(topG, 'push', 'Text','Export MAT', ...
+                'ButtonPushedFcn',@(~,~) app.exportUnitTableToOutput('mat'));
+
+            app.UnitTable = uitable(gl, ...
+                'ColumnEditable', false(1,9), ...
+                'ColumnName', {'Unit #','Type','Connected Streams', ...
+                               'Spec 1 Label','Spec 1 Value', ...
+                               'Spec 2 Label','Spec 2 Value', ...
+                               'Spec 3 Label','Spec 3 Value'});
+            app.UnitTable.Layout.Row = 2;
+
+            app.UnitTableStatusLabel = uilabel(gl, 'Text','', 'FontColor',[0.3 0.3 0.3]);
+            app.UnitTableStatusLabel.Layout.Row = 3;
+
+            app.refreshUnitTablePopup();
+        end
+
+        function onUnitTablePopupClosed(app, src)
+            if ~isempty(src) && isvalid(src)
+                delete(src);
+            end
+            app.UnitTableFig = [];
+            app.UnitTable = [];
+            app.UnitTableStatusLabel = [];
+        end
+
+        function refreshUnitTablePopup(app)
+            if isempty(app.UnitTable) || ~isvalid(app.UnitTable)
+                return;
+            end
+            T = app.buildUnitTable();
+            app.UnitTable.Data = T;
+            app.UnitTable.ColumnName = T.Properties.VariableNames;
+            if isempty(T)
+                status = 'No units defined yet.';
+            else
+                status = sprintf('%d unit(s). Read-only view. Use unit dialogs to edit specs.', height(T));
+            end
+            if ~isempty(app.UnitTableStatusLabel) && isvalid(app.UnitTableStatusLabel)
+                app.UnitTableStatusLabel.Text = status;
+            end
+        end
+
+        function T = buildUnitTable(app)
+            n = numel(app.unitDefs);
+            cols = {'Unit_Index','Type','Connected_Streams', ...
+                    'Spec1_Label','Spec1_Value','Spec2_Label','Spec2_Value','Spec3_Label','Spec3_Value'};
+            if n == 0
+                T = cell2table(cell(0, numel(cols)), 'VariableNames', cols);
+                return;
+            end
+            data = cell(n, numel(cols));
+            for i = 1:n
+                data(i,:) = app.serializeUnitDefRow(i, app.unitDefs{i});
+            end
+            T = cell2table(data, 'VariableNames', cols);
+        end
+
+        function row = serializeUnitDefRow(app, idx, def)
+            row = {idx, '-', '-', '-', '-', '-', '-', '-', '-'};
+            if ~isstruct(def) || ~isfield(def,'type')
+                return;
+            end
+            typ = char(string(def.type));
+            row{2} = typ;
+            row{3} = app.unitConnectedStreams(def);
+
+            specs = app.unitSpecPairs(def);
+            for k = 1:min(3,size(specs,1))
+                row{3 + (k-1)*2 + 1} = specs{k,1};
+                row{3 + (k-1)*2 + 2} = specs{k,2};
+            end
+        end
+
+        function streamText = unitConnectedStreams(app, def)
+            parts = {};
+            fSingle = {'inlet','outlet','source','tear','stream','recycle','purge','outletA','outletB', ...
+                'processInlet','bypassStream','processReturn','hotInlet','hotOutlet','coldInlet','coldOutlet', ...
+                'lhsStream','aStream','bStream'};
+            for i = 1:numel(fSingle)
+                f = fSingle{i};
+                if isfield(def,f)
+                    parts{end+1} = sprintf('%s=%s', f, app.formatSpecValue(def.(f))); %#ok<AGROW>
+                end
+            end
+            if isfield(def,'inlets')
+                parts{end+1} = sprintf('inlets=%s', app.formatSpecValue(def.inlets)); %#ok<AGROW>
+            end
+            if isfield(def,'outlets')
+                parts{end+1} = sprintf('outlets=%s', app.formatSpecValue(def.outlets)); %#ok<AGROW>
+            end
+            if isempty(parts)
+                streamText = '-';
+            else
+                streamText = strjoin(parts, ' | ');
+            end
+        end
+
+        function specs = unitSpecPairs(app, def)
+            specs = {};
+            typ = char(string(def.type));
+            switch typ
+                case 'Mixer'
+                    specs = {'No. inlets', app.formatSpecValue(numel(def.inlets)); 'Outlet', app.formatSpecValue(def.outlet)};
+                case 'Heater'
+                    specs = {'Tout [K]', app.getDefField(def,'Tout'); 'Qdot [W]', app.getDefField(def,'duty')};
+                case 'Cooler'
+                    specs = {'Tout [K]', app.getDefField(def,'Tout'); 'Qdot [W]', app.getDefField(def,'duty')};
+                case 'Compressor'
+                    specs = {'Pressure ratio', app.getDefField(def,'PR'); 'Efficiency', app.getDefField(def,'eta')};
+                case 'Turbine'
+                    specs = {'Pressure ratio', app.getDefField(def,'PR'); 'Efficiency', app.getDefField(def,'eta')};
+                case 'Reactor'
+                    specs = {'Conversion', app.getDefField(def,'conversion'); 'Reactions', app.getDefField(def,'reactions')};
+                case 'ConversionReactor'
+                    specs = {'Key species', app.getDefField(def,'keySpecies'); 'Conversion', app.getDefField(def,'conversion'); 'Mode', app.getDefField(def,'conversionMode')};
+                case 'StoichiometricReactor'
+                    specs = {'Extent', app.getDefField(def,'extent'); 'Mode', app.getDefField(def,'extentMode'); 'Ref species', app.getDefField(def,'referenceSpecies')};
+                case 'YieldReactor'
+                    specs = {'Basis species', app.getDefField(def,'basisSpecies'); 'Conversion', app.getDefField(def,'conversion'); 'Products', app.getDefField(def,'productSpecies')};
+                case 'EquilibriumReactor'
+                    specs = {'Keq', app.getDefField(def,'Keq'); 'Ref species', app.getDefField(def,'referenceSpecies'); 'Stoich nu', app.getDefField(def,'nu')};
+                case 'Separator'
+                    specs = {'Split phi', app.getDefField(def,'phi')};
+                case 'Purge'
+                    specs = {'Purge beta', app.getDefField(def,'beta')};
+                case 'Splitter'
+                    if isfield(def,'splitFractions')
+                        specs = {'Mode', 'fractions'; 'Values', app.getDefField(def,'splitFractions')};
+                    else
+                        specs = {'Mode', 'flows'; 'Values', app.getDefField(def,'specifiedOutletFlows')};
+                    end
+                case 'Bypass'
+                    specs = {'Bypass fraction', app.getDefField(def,'bypassFraction')};
+                case 'Manifold'
+                    specs = {'Route', app.getDefField(def,'route')};
+                case 'Source'
+                    specs = {'Total flow', app.getDefField(def,'totalFlow'); 'Composition', app.getDefField(def,'composition'); 'Comp flows', app.getDefField(def,'componentFlows')};
+                case 'DesignSpec'
+                    specs = {'Metric', app.getDefField(def,'metric'); 'Target', app.getDefField(def,'target'); 'Species idx', app.getDefField(def,'speciesIndex')};
+                case 'Adjust'
+                    specs = {'Field', app.getDefField(def,'field'); 'Index', app.getDefField(def,'index'); 'Bounds', sprintf('[%s, %s]', app.getDefField(def,'minValue'), app.getDefField(def,'maxValue'))};
+                case 'Calculator'
+                    specs = {'LHS field', app.getDefField(def,'lhsField'); 'Operator', app.getDefField(def,'operator'); 'RHS fields', sprintf('%s %s %s', app.getDefField(def,'aField'), app.getDefField(def,'operator'), app.getDefField(def,'bField'))};
+                case 'Constraint'
+                    specs = {'Field', app.getDefField(def,'field'); 'Value', app.getDefField(def,'value'); 'Index', app.getDefField(def,'index')};
+                otherwise
+                    specs = {'Spec struct fields', app.formatSpecValue(fieldnames(def)')};
+            end
+        end
+
+        function val = getDefField(app, def, fld)
+            if isfield(def, fld)
+                val = app.formatSpecValue(def.(fld));
+            else
+                val = '-';
+            end
+        end
+
+        function txt = formatSpecValue(~, val)
+            if ischar(val)
+                txt = val;
+            elseif isstring(val)
+                txt = char(val);
+            elseif isnumeric(val) || islogical(val)
+                if isscalar(val)
+                    txt = num2str(val);
+                else
+                    txt = mat2str(val);
+                end
+            elseif iscell(val)
+                c = cell(size(val));
+                for i = 1:numel(val)
+                    c{i} = char(string(val{i}));
+                end
+                txt = ['{' strjoin(c, ', ') '}'];
+            else
+                txt = char(string(val));
+            end
+        end
+
+        function exportUnitTableToOutput(app, fmt)
+            T = app.buildUnitTable();
+            outDir = app.ensureOutputDir('results');
+            switch lower(fmt)
+                case 'csv'
+                    filepath = fullfile(outDir, app.autoFileName('unit_table', 'csv'));
+                    writetable(T, filepath);
+                case 'mat'
+                    filepath = fullfile(outDir, app.autoFileName('unit_table', 'mat'));
+                    unitTable = T; %#ok<NASGU>
+                    save(filepath, 'unitTable');
+                otherwise
+                    error('MathLab:UnitTable:UnsupportedFormat', 'Unsupported export format "%s"', fmt);
+            end
+            app.setStatus(sprintf('Unit table exported to %s', filepath));
+            if ~isempty(app.UnitTableStatusLabel) && isvalid(app.UnitTableStatusLabel)
+                app.UnitTableStatusLabel.Text = sprintf('Exported %s (%d rows): %s', upper(fmt), height(T), filepath);
+            end
+        end
+    end
+
     % =====================================================================
     %  SAVE / LOAD CONFIG
     % =====================================================================
@@ -2101,6 +2343,7 @@ classdef MathLabApp < handle
             app.refreshUnitsListBox();
             app.refreshFlowsheetDiagram();
             app.updateDOF();
+            app.refreshUnitTablePopup();
             app.updateSensDropdowns();
             app.refreshSpeciesPropsTable();
 


### PR DESCRIPTION
### Motivation
- Provide a quick read-only overview of all unit definitions and their key specs so users can inspect flowsheet configuration without opening each unit dialog. 
- Flatten `unitDefs` into a compact table to mirror the existing stream/results table UX and to enable consistent export workflows.
- Expose export hooks (CSV/MAT) so unit metadata can be saved alongside stream/result exports for reporting and debugging.

### Description
- Added an `Open Unit Table` button in the Setup/Results controls and private UI handles `UnitTableFig`, `UnitTable`, and `UnitTableStatusLabel` to manage the popup. 
- Implemented a popup `uifigure` with a read-only `uitable` and status label via `openUnitTablePopup`, `refreshUnitTablePopup`, and `onUnitTablePopupClosed`. 
- Added serializer helpers `buildUnitTable`, `serializeUnitDefRow`, `unitConnectedStreams`, `unitSpecPairs`, `getDefField`, and `formatSpecValue` to map each `unitDef` into a single flat table row with unit index, type, connected streams, and labeled spec fields (examples: Mixer inlets/outlet; Heater `Tout`/`duty`; Compressor `PR`/`eta`; Reactor conversion/reactions, etc.). 
- Added export hooks `exportUnitTableToOutput` which reuse `ensureOutputDir` and `autoFileName` to export the table as CSV via `writetable` or as MAT via `save`, and wired refresh calls from unit/stream/spec change points (`applySpecies`, `commitUnit`, `removeSelectedUnit`, and config load) so the view stays in sync. 

### Testing
- Ran repository checks: `git diff --check` reported no issues. 
- Confirmed working tree status with `git status --short`. 
- Did not run MATLAB/Octave runtime tests in this environment per project constraints (GUI/display and `uifigure` require MATLAB runtime).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f12560a4c83338763f115e1f70314)