### PR TITLE
Fix thermodynamic unit solver convergence issues

### DIFF
--- a/+proc/+units/Compressor.m
+++ b/+proc/+units/Compressor.m
@@ -61,7 +61,7 @@ classdef Compressor < handle
             eqs(end+1) = obj.outlet.P - P2;
 
             % Isentropic calculation
-            z = obj.inlet.y(:)';
+            z = obj.inlet.y(:)' / max(sum(obj.inlet.y), eps);
             T1 = obj.inlet.T;
             P1 = obj.inlet.P;
             h1 = obj.thermoMix.h_mix_sensible(T1, z);
@@ -95,7 +95,7 @@ classdef Compressor < handle
 
         function W = getPower(obj)
             %GETPOWER Compute shaft power [kW] from current stream states.
-            z = obj.inlet.y(:)';
+            z = obj.inlet.y(:)' / max(sum(obj.inlet.y), eps);
             h1 = obj.thermoMix.h_mix_sensible(obj.inlet.T, z);
             h2 = obj.thermoMix.h_mix_sensible(obj.outlet.T, z);
             W = obj.inlet.n_dot * (h2 - h1);

--- a/+proc/+units/Cooler.m
+++ b/+proc/+units/Cooler.m
@@ -64,7 +64,7 @@ classdef Cooler < handle
             Pspec = obj.resolvedOutletPressure();
             eqs(end+1) = obj.outlet.P - Pspec;
 
-            z_in = y_in.';
+            z_in = y_in.' / max(sum(y_in), eps);
 
             if isfinite(obj.Tout)
                 % Temperature spec
@@ -82,35 +82,23 @@ classdef Cooler < handle
         function labels = equationLabels(obj)
             ns = numel(obj.inlet.y);
             labels = strings(ns + 2, 1);
+            prefix = sprintf('Cooler %s->%s', ...
+                string(obj.inlet.name), string(obj.outlet.name));
             for i = 1:ns
-                labels(i) = sprintf('Cooler %s->%s residual(%d): n_out*y_out(%d) - n_in*y_in(%d)', ...
-                    string(obj.inlet.name), string(obj.outlet.name), i, i, i);
+                labels(i) = sprintf('%s: component %d mole flow', prefix, i);
             end
-            if isfinite(obj.dP)
-                pLabel = 'P_out - (P_in + dP)';
-            elseif isfinite(obj.Pout)
-                pLabel = 'P_out - P_spec';
-            elseif isfinite(obj.PR)
-                pLabel = 'P_out - PR*P_in';
-            else
-                pLabel = 'P_out - P_in';
-            end
-            labels(ns+1) = sprintf('Cooler %s->%s residual(%d): %s', ...
-                string(obj.inlet.name), string(obj.outlet.name), ns+1, pLabel);
+            labels(ns+1) = sprintf('%s: pressure', prefix);
             if isfinite(obj.Tout)
-                labels(ns+2) = sprintf('Cooler %s->%s residual(%d): T_out - T_spec', ...
-                    string(obj.inlet.name), string(obj.outlet.name), ns+2);
+                labels(ns+2) = sprintf('%s: temperature spec', prefix);
             elseif isfinite(obj.duty)
-                labels(ns+2) = sprintf('Cooler %s->%s residual(%d): duty - n_in*(h_out-h_in)', ...
-                    string(obj.inlet.name), string(obj.outlet.name), ns+2);
+                labels(ns+2) = sprintf('%s: enthalpy balance', prefix);
             else
-                labels(ns+2) = sprintf('Cooler %s->%s residual(%d): energy/temperature spec (unset)', ...
-                    string(obj.inlet.name), string(obj.outlet.name), ns+2);
+                labels(ns+2) = sprintf('%s: energy spec (unset)', prefix);
             end
         end
 
         function Q = getDuty(obj)
-            z = obj.inlet.y(:)';
+            z = obj.inlet.y(:)' / max(sum(obj.inlet.y), eps);
             h_in  = obj.thermoMix.h_mix_sensible(obj.inlet.T, z);
             h_out = obj.thermoMix.h_mix_sensible(obj.outlet.T, z);
             Q = obj.inlet.n_dot * (h_out - h_in);

--- a/+proc/+units/HeatExchanger.m
+++ b/+proc/+units/HeatExchanger.m
@@ -68,8 +68,8 @@ classdef HeatExchanger < handle
             eqs(end+1) = obj.coldOutlet.P - obj.coldInlet.P;
 
             % Enthalpy calculations
-            zh = obj.hotInlet.y(:)';
-            zc = obj.coldInlet.y(:)';
+            zh = obj.hotInlet.y(:)' / max(sum(obj.hotInlet.y), eps);
+            zc = obj.coldInlet.y(:)' / max(sum(obj.coldInlet.y), eps);
 
             h_h_in  = obj.thermoMix.h_mix_sensible(obj.hotInlet.T,  zh);
             h_h_out = obj.thermoMix.h_mix_sensible(obj.hotOutlet.T, zh);
@@ -114,13 +114,21 @@ classdef HeatExchanger < handle
             end
             idx = idx + 1; labels(idx) = "HX: hot pressure";
             idx = idx + 1; labels(idx) = "HX: cold pressure";
-            idx = idx + 1; labels(idx) = "HX: spec equation";
+            if isfinite(obj.Th_out)
+                idx = idx + 1; labels(idx) = "HX: temperature spec (Th_out)";
+            elseif isfinite(obj.Tc_out)
+                idx = idx + 1; labels(idx) = "HX: temperature spec (Tc_out)";
+            elseif isfinite(obj.duty)
+                idx = idx + 1; labels(idx) = "HX: energy spec (duty)";
+            else
+                idx = idx + 1; labels(idx) = "HX: spec equation";
+            end
             idx = idx + 1; labels(idx) = "HX: energy balance";
         end
 
         function Q = getDuty(obj)
             %GETDUTY Compute heat duty [kW] from current states.
-            zh = obj.hotInlet.y(:)';
+            zh = obj.hotInlet.y(:)' / max(sum(obj.hotInlet.y), eps);
             h_h_in  = obj.thermoMix.h_mix_sensible(obj.hotInlet.T, zh);
             h_h_out = obj.thermoMix.h_mix_sensible(obj.hotOutlet.T, zh);
             Q = obj.hotInlet.n_dot * (h_h_in - h_h_out);

--- a/+proc/+units/Mixer.m
+++ b/+proc/+units/Mixer.m
@@ -37,6 +37,18 @@ classdef Mixer < handle
             eqs(end+1) = obj.outlet.P - obj.inlets{1}.P;
         end
 
+        function labels = equationLabels(obj)
+            nspecies = length(obj.outlet.y);
+            labels = strings(nspecies + 2, 1);
+            inNames = cellfun(@(s) char(string(s.name)), obj.inlets, 'Uni', false);
+            prefix = sprintf('Mixer {%s}->%s', strjoin(inNames, ','), string(obj.outlet.name));
+            for j = 1:nspecies
+                labels(j) = sprintf('%s: component %d mole flow', prefix, j);
+            end
+            labels(nspecies+1) = sprintf('%s: temperature', prefix);
+            labels(nspecies+2) = sprintf('%s: pressure', prefix);
+        end
+
         function str = describe(obj)
             inNames = cellfun(@(s) char(string(s.name)), obj.inlets, 'Uni', false);
             str = sprintf('Mixer: {%s} -> %s', strjoin(inNames, ', '), string(obj.outlet.name));

--- a/+proc/+units/Turbine.m
+++ b/+proc/+units/Turbine.m
@@ -57,7 +57,7 @@ classdef Turbine < handle
             eqs(end+1) = obj.outlet.P - P2;
 
             % Isentropic calculation
-            z = obj.inlet.y(:)';
+            z = obj.inlet.y(:)' / max(sum(obj.inlet.y), eps);
             T1 = obj.inlet.T;
             P1 = obj.inlet.P;
             h1 = obj.thermoMix.h_mix_sensible(T1, z);
@@ -89,7 +89,7 @@ classdef Turbine < handle
 
         function W = getPower(obj)
             %GETPOWER Power produced [kW]. W > 0 = power out.
-            z = obj.inlet.y(:)';
+            z = obj.inlet.y(:)' / max(sum(obj.inlet.y), eps);
             h1 = obj.thermoMix.h_mix_sensible(obj.inlet.T, z);
             h2 = obj.thermoMix.h_mix_sensible(obj.outlet.T, z);
             W = obj.inlet.n_dot * (h1 - h2);

--- a/MathLabApp.m
+++ b/MathLabApp.m
@@ -1987,6 +1987,7 @@ classdef MathLabApp < handle
 
             try
                 solver = fs.solve('maxIter',maxIt,'tolAbs',tol, ...
+                    'autoScale',true, ...
                     'printToConsole',false,'iterCallback',@iterCb);
                 app.lastSolver = solver;
 
@@ -4140,7 +4141,7 @@ classdef MathLabApp < handle
                 try
                     app.applySensParam(paramChoice, unitIdx, vals(p), unitSel);
                     fs = app.buildFlowsheet();
-                    fs.solve('maxIter',sensMaxIt,'tolAbs',sensTol,'printToConsole',false);
+                    fs.solve('maxIter',sensMaxIt,'tolAbs',sensTol,'autoScale',true,'printToConsole',false);
                     results(p) = app.extractOutput(outStreamName, outFieldStr);
                 catch
                     results(p) = NaN;

--- a/runFromConfig.m
+++ b/runFromConfig.m
@@ -83,7 +83,10 @@ function [T, solver] = runFromConfig(configFile, varargin)
     fprintf('MaxIter: %d   Tolerance: %.2e\n\n', maxIter, tolAbs);
 
     % --- Solve ---
+    autoScale = true;
+    if isfield(cfg, 'autoScale'), autoScale = cfg.autoScale; end
     solver = fs.solve('maxIter', maxIter, 'tolAbs', tolAbs, ...
+        'autoScale', autoScale, ...
         'printToConsole', opts.verbose, 'consoleStride', 1);
 
     % --- Results ---


### PR DESCRIPTION
Four compounding bugs caused wrong results when thermodynamic units (Heater, Cooler, HeatExchanger, Compressor, Turbine) were included:

1. Add auto-scaling to ProcessSolver that derives per-equation weights from initial residual magnitudes, balancing component balance (~1-10), pressure (~1e5), and energy (~1e3-1e5) equations. Enabled by default in MathLabApp and runFromConfig.

2. Fix equation labels in Heater, Cooler, and HeatExchanger so the keyword-based weight classification (pressure/temperature/enthalpy/ mole flow) matches correctly. Previously labels like "T_out - T_spec" missed all keywords and fell through to default weight.

3. Add equationLabels() to Mixer with proper keywords for mole flow, temperature, and pressure classification.

4. Normalize composition vectors in all five thermodynamic units before passing to enthalpy calculations. Previously raw y was used directly; during solver iterations sum(y) can drift from 1.0, causing incorrect energy balance residuals.

https://claude.ai/code/session_01Hoxh2AeAA5yRcEPTAiLToU