### PR TITLE
Refactor MathLabApp shell to use tab controllers and shared AppState

### DIFF
--- a/+ui/+tabs/ResultsTabController.m
+++ b/+ui/+tabs/ResultsTabController.m
@@ -1,0 +1,13 @@
+classdef ResultsTabController < handle
+    properties
+        State
+        Services struct
+    end
+
+    methods
+        function obj = ResultsTabController(state, services)
+            obj.State = state;
+            obj.Services = services;
+        end
+    end
+end

--- a/+ui/+tabs/SensitivityTabController.m
+++ b/+ui/+tabs/SensitivityTabController.m
@@ -1,0 +1,25 @@
+classdef SensitivityTabController < handle
+    properties
+        State
+        Services struct
+    end
+
+    methods
+        function obj = SensitivityTabController(state, services)
+            obj.State = state;
+            obj.Services = services;
+        end
+
+        function onRunSensitivity(obj)
+            obj.Services.runSensitivity();
+        end
+
+        function applySensParam(obj, paramChoice, val)
+            obj.Services.applySensParam(paramChoice, val);
+        end
+
+        function val = extractOutput(obj, streamName, fieldStr)
+            val = obj.Services.extractOutput(streamName, fieldStr);
+        end
+    end
+end

--- a/+ui/+tabs/SolveTabController.m
+++ b/+ui/+tabs/SolveTabController.m
@@ -1,0 +1,23 @@
+classdef SolveTabController < handle
+    properties
+        State
+        Services struct
+    end
+
+    methods
+        function obj = SolveTabController(state, services)
+            obj.State = state;
+            obj.Services = services;
+        end
+
+        function runSolve(obj)
+            obj.Services.runSolve();
+        end
+
+        function updateConvergence(obj, iter, residual)
+            if isfield(obj.Services, 'updateConvergence')
+                obj.Services.updateConvergence(iter, residual);
+            end
+        end
+    end
+end

--- a/+ui/+tabs/SpeciesTabController.m
+++ b/+ui/+tabs/SpeciesTabController.m
@@ -1,0 +1,59 @@
+classdef SpeciesTabController < handle
+    properties
+        State
+        Services struct
+    end
+
+    methods
+        function obj = SpeciesTabController(state, services)
+            obj.State = state;
+            obj.Services = services;
+        end
+
+        function refreshSpeciesTable(obj, speciesTable)
+            N = numel(obj.State.speciesNames);
+            data = cell(N, 2);
+            for i = 1:N
+                data{i,1} = obj.State.speciesNames{i};
+                data{i,2} = obj.State.speciesMW(i);
+            end
+            speciesTable.Data = data;
+        end
+
+        function onSpeciesTableEdit(obj, evt)
+            r = evt.Indices(1); c = evt.Indices(2);
+            if r < 1 || r > numel(obj.State.speciesNames), return; end
+            if c == 1
+                obj.State.speciesNames{r} = evt.NewData;
+            elseif c == 2
+                obj.State.speciesMW(r) = evt.NewData;
+            end
+        end
+
+        function addSpeciesRow(obj, nameField, mwField, speciesTable)
+            nm = strtrim(nameField.Value);
+            if isempty(nm), return; end
+            obj.State.speciesNames{end+1} = nm;
+            obj.State.speciesMW(end+1) = mwField.Value;
+            nameField.Value = '';
+            obj.refreshSpeciesTable(speciesTable);
+        end
+
+        function removeSpeciesRow(obj, speciesTable)
+            sel = speciesTable.Selection;
+            if isempty(sel), return; end
+            r = sel(1);
+            if r >= 1 && r <= numel(obj.State.speciesNames)
+                obj.State.speciesNames(r) = [];
+                obj.State.speciesMW(r) = [];
+                obj.refreshSpeciesTable(speciesTable);
+            end
+        end
+
+        function applySpecies(obj)
+            if isfield(obj.Services, 'applySpeciesReset')
+                obj.Services.applySpeciesReset();
+            end
+        end
+    end
+end

--- a/+ui/+tabs/StreamsTabController.m
+++ b/+ui/+tabs/StreamsTabController.m
@@ -1,0 +1,29 @@
+classdef StreamsTabController < handle
+    properties
+        State
+        Services struct
+    end
+
+    methods
+        function obj = StreamsTabController(state, services)
+            obj.State = state;
+            obj.Services = services;
+        end
+
+        function onStreamValEdit(obj, src, evt)
+            obj.Services.onStreamValEdit(src, evt);
+        end
+
+        function onKnownEdit(obj, src, evt)
+            obj.Services.onKnownEdit(src, evt);
+        end
+
+        function addStreamFromUI(obj)
+            obj.Services.addStreamFromUI();
+        end
+
+        function removeSelectedStream(obj)
+            obj.Services.removeSelectedStream();
+        end
+    end
+end

--- a/+ui/+tabs/UnitsTabController.m
+++ b/+ui/+tabs/UnitsTabController.m
@@ -1,0 +1,21 @@
+classdef UnitsTabController < handle
+    properties
+        State
+        Services struct
+    end
+
+    methods
+        function obj = UnitsTabController(state, services)
+            obj.State = state;
+            obj.Services = services;
+        end
+
+        function dialogReactor(obj, sNames, editIdx)
+            obj.Services.dialogReactor(sNames, editIdx);
+        end
+
+        function dialogAdjust(obj, sNames, editIdx)
+            obj.Services.dialogAdjust(sNames, editIdx);
+        end
+    end
+end

--- a/+ui/AppState.m
+++ b/+ui/AppState.m
@@ -1,0 +1,16 @@
+classdef AppState < handle
+    %APPSTATE Lightweight shared application state.
+    properties
+        speciesNames cell = {'H2','O2','H2O'}
+        speciesMW double = [2.016, 32.00, 18.015]
+        streams cell = {}
+        units cell = {}
+        unitDefs cell = {}
+        lastSolver = []
+        lastFlowsheet = []
+        metadata struct = struct( ...
+            'projectTitle', 'MathLab_Project', ...
+            'unitPrefs', struct('flow','kmol/s','temperature','K','pressure','Pa','duty','kW','power','kW'), ...
+            'lastExportPath', '')
+    end
+end

--- a/MathLabApp.m
+++ b/MathLabApp.m
@@ -174,6 +174,14 @@ classdef MathLabApp < handle
     %  MODEL STATE
     % =====================================================================
     properties (Access = private)
+        AppState ui.AppState
+        SpeciesController ui.tabs.SpeciesTabController
+        StreamsController ui.tabs.StreamsTabController
+        UnitsController ui.tabs.UnitsTabController
+        SolveController ui.tabs.SolveTabController
+        ResultsController ui.tabs.ResultsTabController
+        SensitivityController ui.tabs.SensitivityTabController
+
         speciesNames cell   = {'H2','O2','H2O'}
         speciesMW    double = [2.016, 32.00, 18.015]
 
@@ -199,6 +207,8 @@ classdef MathLabApp < handle
     % =====================================================================
     methods (Access = public)
         function app = MathLabApp(configFile)
+            app.AppState = ui.AppState();
+            app.initControllers();
             app.buildUI();
             if nargin >= 1 && ~isempty(configFile)
                 app.loadConfig(configFile);
@@ -213,6 +223,53 @@ classdef MathLabApp < handle
     %  UI CONSTRUCTION
     % =====================================================================
     methods (Access = private)
+
+        function initControllers(app)
+            app.syncModelToState();
+            app.SpeciesController = ui.tabs.SpeciesTabController(app.AppState, struct( ...
+                'applySpeciesReset', @() app.applySpeciesCore()));
+            app.StreamsController = ui.tabs.StreamsTabController(app.AppState, struct( ...
+                'onStreamValEdit', @(src,evt) app.onStreamValEditCore(src,evt), ...
+                'onKnownEdit', @(src,evt) app.onKnownEditCore(src,evt), ...
+                'addStreamFromUI', @() app.addStreamFromUICore(), ...
+                'removeSelectedStream', @() app.removeSelectedStreamCore()));
+            app.UnitsController = ui.tabs.UnitsTabController(app.AppState, struct( ...
+                'dialogReactor', @(sNames,editIdx) app.dialogReactorCore(sNames,editIdx), ...
+                'dialogAdjust', @(sNames,editIdx) app.dialogAdjustCore(sNames,editIdx)));
+            app.SolveController = ui.tabs.SolveTabController(app.AppState, struct( ...
+                'runSolve', @() app.runSolverCore()));
+            app.ResultsController = ui.tabs.ResultsTabController(app.AppState, struct());
+            app.SensitivityController = ui.tabs.SensitivityTabController(app.AppState, struct( ...
+                'runSensitivity', @() app.runSensitivityCore(), ...
+                'applySensParam', @(paramChoice,val) app.applySensParamCore(paramChoice,val), ...
+                'extractOutput', @(streamName,fieldStr) app.extractOutputCore(streamName,fieldStr)));
+        end
+
+        function syncModelToState(app)
+            app.AppState.speciesNames = app.speciesNames;
+            app.AppState.speciesMW = app.speciesMW;
+            app.AppState.streams = app.streams;
+            app.AppState.units = app.units;
+            app.AppState.unitDefs = app.unitDefs;
+            app.AppState.lastSolver = app.lastSolver;
+            app.AppState.lastFlowsheet = app.lastFlowsheet;
+            app.AppState.metadata.projectTitle = app.projectTitle;
+            app.AppState.metadata.unitPrefs = app.unitPrefs;
+            app.AppState.metadata.lastExportPath = app.lastExportPath;
+        end
+
+        function syncStateToModel(app)
+            app.speciesNames = app.AppState.speciesNames;
+            app.speciesMW = app.AppState.speciesMW;
+            app.streams = app.AppState.streams;
+            app.units = app.AppState.units;
+            app.unitDefs = app.AppState.unitDefs;
+            app.lastSolver = app.AppState.lastSolver;
+            app.lastFlowsheet = app.AppState.lastFlowsheet;
+            app.projectTitle = app.AppState.metadata.projectTitle;
+            app.unitPrefs = app.AppState.metadata.unitPrefs;
+            app.lastExportPath = app.AppState.metadata.lastExportPath;
+        end
 
         function buildUI(app)
             app.Fig = uifigure('Name','MathLab — Process Solver', ...
@@ -844,44 +901,37 @@ classdef MathLabApp < handle
     methods (Access = private)
 
         function refreshSpeciesTable(app)
-            N = numel(app.speciesNames);
-            data = cell(N, 2);
-            for i = 1:N
-                data{i,1} = app.speciesNames{i};
-                data{i,2} = app.speciesMW(i);
-            end
-            app.SpeciesTable.Data = data;
+            app.syncModelToState();
+            app.SpeciesController.refreshSpeciesTable(app.SpeciesTable);
+            app.syncStateToModel();
         end
 
         function onSpeciesTableEdit(app, ~, evt)
-            r = evt.Indices(1); c = evt.Indices(2);
-            if r < 1 || r > numel(app.speciesNames), return; end
-            if c == 1,     app.speciesNames{r} = evt.NewData;
-            elseif c == 2, app.speciesMW(r) = evt.NewData;
-            end
+            app.syncModelToState();
+            app.SpeciesController.onSpeciesTableEdit(evt);
+            app.syncStateToModel();
         end
 
         function addSpeciesRow(app)
-            nm = strtrim(app.NewSpeciesName.Value);
-            if isempty(nm), return; end
-            app.speciesNames{end+1} = nm;
-            app.speciesMW(end+1) = app.NewSpeciesMW.Value;
-            app.NewSpeciesName.Value = '';
-            app.refreshSpeciesTable();
+            app.syncModelToState();
+            app.SpeciesController.addSpeciesRow(app.NewSpeciesName, app.NewSpeciesMW, app.SpeciesTable);
+            app.syncStateToModel();
         end
 
         function removeSpeciesRow(app)
-            sel = app.SpeciesTable.Selection;
-            if isempty(sel), return; end
-            r = sel(1);
-            if r >= 1 && r <= numel(app.speciesNames)
-                app.speciesNames(r) = [];
-                app.speciesMW(r) = [];
-                app.refreshSpeciesTable();
-            end
+            app.syncModelToState();
+            app.SpeciesController.removeSpeciesRow(app.SpeciesTable);
+            app.syncStateToModel();
         end
 
         function applySpecies(app)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            app.SpeciesController.applySpecies();
+            app.syncStateToModel();
+        end
+
+        function applySpeciesCore(app)
             if isempty(app.speciesNames)
                 uialert(app.Fig, 'Species list cannot be empty.', 'Error'); return;
             end
@@ -964,6 +1014,13 @@ classdef MathLabApp < handle
         end
 
         function addStreamFromUI(app)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            app.StreamsController.addStreamFromUI();
+            app.syncStateToModel();
+        end
+
+        function addStreamFromUICore(app)
             name = strtrim(app.StreamNameField.Value);
             if isempty(name)
                 uialert(app.Fig,'Enter a name.','Error'); return;
@@ -985,6 +1042,13 @@ classdef MathLabApp < handle
         end
 
         function removeSelectedStream(app)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            app.StreamsController.removeSelectedStream();
+            app.syncStateToModel();
+        end
+
+        function removeSelectedStreamCore(app)
             sel = app.StreamValTable.Selection;
             if isempty(sel), return; end
             row = sel(1);
@@ -1039,7 +1103,14 @@ classdef MathLabApp < handle
             app.StreamKnownTable.ColumnEditable = [false, true, true, true, true];
         end
 
-        function onStreamValEdit(app, ~, evt)
+        function onStreamValEdit(app, src, evt)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            app.StreamsController.onStreamValEdit(src, evt);
+            app.syncStateToModel();
+        end
+
+        function onStreamValEditCore(app, ~, evt)
             row = evt.Indices(1); col = evt.Indices(2);
             if row < 1 || row > numel(app.streams), return; end
             s = app.streams{row};
@@ -1055,7 +1126,14 @@ classdef MathLabApp < handle
             app.refreshStreamTables();
         end
 
-        function onKnownEdit(app, ~, evt)
+        function onKnownEdit(app, src, evt)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            app.StreamsController.onKnownEdit(src, evt);
+            app.syncStateToModel();
+        end
+
+        function onKnownEditCore(app, ~, evt)
             row = evt.Indices(1); col = evt.Indices(2);
             if row < 1 || row > numel(app.streams), return; end
             s = app.streams{row};
@@ -1552,6 +1630,13 @@ classdef MathLabApp < handle
         end
 
         function dialogReactor(app, sNames, editIdx)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            app.UnitsController.dialogReactor(sNames, editIdx);
+            app.syncStateToModel();
+        end
+
+        function dialogReactorCore(app, sNames, editIdx)
             if nargin<3, editIdx=[]; end
             ns = numel(app.speciesNames);
             spStr = strjoin(app.speciesNames,', ');
@@ -2102,6 +2187,13 @@ classdef MathLabApp < handle
     methods (Access = private)
 
         function runSolver(app)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            app.SolveController.runSolve();
+            app.syncStateToModel();
+        end
+
+        function runSolverCore(app)
             app.syncStreamsFromTable();
 
             if isempty(app.streams)
@@ -4307,6 +4399,13 @@ classdef MathLabApp < handle
         end
 
         function dialogAdjust(app, sNames, editIdx)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            app.UnitsController.dialogAdjust(sNames, editIdx);
+            app.syncStateToModel();
+        end
+
+        function dialogAdjustCore(app, sNames, editIdx)
             if nargin<3, editIdx=[]; end
             [d, ctrls] = app.makeDialog('Adjust Controller', 640, 280, ...
                 {{'DesignSpec unit index:','numeric',1,'Which DesignSpec unit this controller satisfies.'}, ...
@@ -5164,6 +5263,13 @@ classdef MathLabApp < handle
         end
 
         function runSensitivity(app)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            app.SensitivityController.onRunSensitivity();
+            app.syncStateToModel();
+        end
+
+        function runSensitivityCore(app)
             app.syncStreamsFromTable();
             if isempty(app.streams) || isempty(app.units)
                 uialert(app.Fig,'Add streams and units first.','Error'); return;
@@ -5257,6 +5363,13 @@ classdef MathLabApp < handle
         end
 
         function applySensParam(app, paramChoice, val)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            app.SensitivityController.applySensParam(paramChoice, val);
+            app.syncStateToModel();
+        end
+
+        function applySensParamCore(app, paramChoice, val)
             [unitIdx, fieldName, vecIdx, streamName] = app.parseSensParam(paramChoice);
             if ~isempty(unitIdx) && unitIdx <= numel(app.units) && ~isempty(fieldName)
                 u = app.units{unitIdx};
@@ -5310,6 +5423,13 @@ classdef MathLabApp < handle
         end
 
         function val = extractOutput(app, streamName, fieldStr)
+            % Temporary wrapper during controller migration.
+            app.syncModelToState();
+            val = app.SensitivityController.extractOutput(streamName, fieldStr);
+            app.syncStateToModel();
+        end
+
+        function val = extractOutputCore(app, streamName, fieldStr)
             s = app.findStream(streamName);
             if isempty(s), val=NaN; return; end
             if strcmp(fieldStr,'n_dot'), val=s.n_dot;


### PR DESCRIPTION
### Motivation
- Reduce monolithic `MathLabApp` by moving tab-specific behavior into lightweight controllers and introduce a single shared state object to simplify migration and future testing.
- Keep the application shell responsibilities (window/tab creation, status bar, and high-level routing) while enabling controllers to own tab logic and UI callbacks.
- Preserve existing public method signatures during migration by adding temporary wrapper methods so existing call sites remain valid.

### Description
- Added a new `+ui/AppState.m` handle class holding `speciesNames`, `speciesMW`, `streams`, `units`, `unitDefs`, `lastSolver`, `lastFlowsheet` and a `metadata` struct for project title, unit prefs and last export path.
- Created per-tab controllers under `+ui/+tabs/`: `SpeciesTabController`, `StreamsTabController`, `UnitsTabController`, `SolveTabController`, `ResultsTabController`, and `SensitivityTabController` with minimal service wiring and basic APIs for the migrated anchors.
- Updated `MathLabApp.m` to instantiate `AppState` and all controllers, added `syncModelToState`/`syncStateToModel` helpers, and routed behavior to controllers via service delegates while keeping temporary wrapper methods for existing callbacks; also added `*Core` implementations for migrated logic.
- Migrated key anchors into controller flow and wrapper/core pairs: species table refresh/edit/add/remove and `applySpecies`; stream add/remove and value/known callbacks; unit dialogs `dialogReactor`/`dialogAdjust`; solve entrypoint `runSolver`; sensitivity helpers `runSensitivity`, `applySensParam`, and `extractOutput`.

### Testing
- Verified repository file list with `rg --files` and confirmed the `+ui/` package and controller files exist (succeeded).
- Printed/inspected new controller and `AppState` files with `nl`/`sed` to confirm expected methods and properties (succeeded).
- Searched `MathLabApp.m` for migrated wrapper and `*Core` function anchors with `rg` to ensure routing and sync helpers were added (succeeded).
- Did not run MATLAB/Octave runtime tests per project instruction since the environment does not have MATLAB/Octave installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a0a079103883338d363f0fcff757ec)