### PR TITLE
Replace 'warning once' with instance-based warning suppression

### DIFF
--- a/+proc/+thermo/ShomateSpecies.m
+++ b/+proc/+thermo/ShomateSpecies.m
@@ -37,6 +37,10 @@ classdef ShomateSpecies < handle
         notes       string = ""
     end
 
+    properties (Access = private)
+        didWarnOutOfRange logical = false
+    end
+
     methods
         function obj = ShomateSpecies(name, MW, ranges, varargin)
             %SHOMATESPECIES Construct species with Shomate data.
@@ -68,9 +72,12 @@ classdef ShomateSpecies < handle
             elseif T > obj.ranges(end).Tmax
                 c = obj.ranges(end);
             end
-            warning('once', 'proc.thermo:outOfRange', ...
-                '%s: T=%.1f K outside Shomate range [%.0f, %.0f]. Clamping.', ...
-                obj.name, T, obj.ranges(1).Tmin, obj.ranges(end).Tmax);
+            if ~obj.didWarnOutOfRange
+                warning('proc.thermo:outOfRange', ...
+                    '%s: T=%.1f K outside Shomate range [%.0f, %.0f]. Clamping.', ...
+                    obj.name, T, obj.ranges(1).Tmin, obj.ranges(end).Tmax);
+                obj.didWarnOutOfRange = true;
+            end
         end
 
         function cp = cp_molar(obj, T)


### PR DESCRIPTION
## Summary
Modified the out-of-range temperature warning mechanism in `ShomateSpecies` to use instance-based suppression instead of MATLAB's `'once'` warning state, ensuring warnings are shown once per object instance rather than globally.

## Key Changes
- Added private property `didWarnOutOfRange` to track whether a warning has been issued for this specific instance
- Replaced `warning('once', ...)` call with conditional logic that checks the instance property before issuing the warning
- Set `didWarnOutOfRange = true` after the first warning to prevent subsequent warnings for the same object

## Implementation Details
This change improves warning behavior in multi-instance scenarios where multiple `ShomateSpecies` objects may be used. Previously, the global `'once'` state meant that if one object warned about out-of-range temperatures, other objects would be silenced. Now each instance maintains its own warning state, allowing users to see warnings from different species objects independently while still avoiding redundant warnings from the same object.

https://claude.ai/code/session_01FKXbmKzD14yvfe32FE8z51